### PR TITLE
fix(jetty12): more align RequestURI attr creation with that of Jetty 11

### DIFF
--- a/jetty11/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/jetty11/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -68,7 +68,7 @@ public class JettyBasicTest {
 
     @Test
     public void eventGoesToAppenders() throws Exception {
-        URL url = new URL(JETTY_FIXTURE.getUrl());
+        URL url = new URL("http://localhost:" + RANDOM_SERVER_PORT + "/path/foo%20bar;param?query#fragment");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
 
@@ -82,6 +82,7 @@ public class JettyBasicTest {
 
         assertEquals("127.0.0.1", event.getRemoteHost());
         assertEquals("localhost", event.getServerName());
+        assertEquals("/path/foo%20bar;param", event.getRequestURI());
         listAppender.list.clear();
     }
 

--- a/jetty11/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/jetty11/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -68,7 +68,7 @@ public class JettyBasicTest {
 
     @Test
     public void eventGoesToAppenders() throws Exception {
-        URL url = new URL("http://localhost:" + RANDOM_SERVER_PORT + "/path/foo%20bar;param?query#fragment");
+        URL url = new URL(JETTY_FIXTURE.getUrl() + "path/foo%20bar;param?query#fragment");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
 

--- a/jetty12/src/main/java/ch/qos/logback/access/jetty/RequestWrapper.java
+++ b/jetty12/src/main/java/ch/qos/logback/access/jetty/RequestWrapper.java
@@ -144,10 +144,7 @@ public class RequestWrapper implements HttpServletRequest, WrappedHttpRequest {
 
     @Override
     public String getRequestURI() {
-
-        HttpURI.Mutable mutable = HttpURI.build(request.getHttpURI().getDecodedPath());
-        mutable.query(null);
-        return mutable.asString();
+        return request.getHttpURI().getPath();
     }
 
     @Override

--- a/jetty12/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/jetty12/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -68,7 +68,7 @@ public class JettyBasicTest {
 
     @Test
     public void eventGoesToAppenders() throws Exception {
-        URL url = new URL(JETTY_FIXTURE.getUrl());
+        URL url = new URL("http://localhost:" + RANDOM_SERVER_PORT + "/path/foo%20bar;param?query#fragment");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
 
@@ -82,6 +82,7 @@ public class JettyBasicTest {
 
         assertEquals("127.0.0.1", event.getRemoteHost());
         assertEquals("localhost", event.getServerName());
+        assertEquals("/path/foo%20bar;param", event.getRequestURI());
         listAppender.list.clear();
     }
 

--- a/jetty12/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
+++ b/jetty12/src/test/java/ch/qos/logback/access/jetty/JettyBasicTest.java
@@ -68,7 +68,7 @@ public class JettyBasicTest {
 
     @Test
     public void eventGoesToAppenders() throws Exception {
-        URL url = new URL("http://localhost:" + RANDOM_SERVER_PORT + "/path/foo%20bar;param?query#fragment");
+        URL url = new URL(JETTY_FIXTURE.getUrl() + "path/foo%20bar;param?query#fragment");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setDoInput(true);
 


### PR DESCRIPTION
Ref: https://github.com/qos-ch/logback-access/issues/4#issuecomment-2049509595

## Why

By the following pull request, now provides the path part of the URI in Jetty 12 as well. 

- https://github.com/qos-ch/logback-access/pull/5

However, `HttpURI::getDecodedPath` method returns a decoded path, so the behavior is different from other environments, such as Jetty 11.

## What

- In Jetty 12 module, use `HttpURI::getPath` method instead, which returns the raw format
- Add tests for RequestURI attribute creation results
