### PR TITLE
gh-18 Add locale option and `STRICT` constant to DateConverter

### DIFF
--- a/common-blackbox/src/test/java/ch/qos/logback/access/common/blackbox/pattern/ConverterTest.java
+++ b/common-blackbox/src/test/java/ch/qos/logback/access/common/blackbox/pattern/ConverterTest.java
@@ -106,6 +106,50 @@ public class ConverterTest {
         assertEquals(converter.internalCachingDateFormatter().format(event.getTimeStamp()), result);
     }
 
+    @Test
+    public void testDateConverter_en_locale() {
+        DateConverter converter = new DateConverter();
+        List<String> optionsList = Lists.list(
+                CoreConstants.CLF_DATE_PATTERN,
+                "UTC",
+                "en");
+
+        converter.setOptionList(optionsList);
+        converter.start();
+        Instant instant = Instant.parse("2022-09-21T10:30:20.800Z");
+
+        System.out.println(instant.toEpochMilli());
+
+        event.setTimeStamp(instant.toEpochMilli());
+        String result = converter.convert(event);
+        assertEquals("21/Sep/2022:10:30:20 +0000", result);
+        System.out.println(result);
+
+        assertEquals(converter.internalCachingDateFormatter().format(event.getTimeStamp()), result);
+    }
+
+    @Test
+    public void testDateConverter_en_GB_locale() {
+        DateConverter converter = new DateConverter();
+        List<String> optionsList = Lists.list(
+                CoreConstants.CLF_DATE_PATTERN,
+                "UTC",
+                "en-GB");
+
+        converter.setOptionList(optionsList);
+        converter.start();
+        Instant instant = Instant.parse("2022-09-21T10:30:20.800Z");
+
+        System.out.println(instant.toEpochMilli());
+
+        event.setTimeStamp(instant.toEpochMilli());
+        String result = converter.convert(event);
+        // September is now 'Sept' in the en_GB locale (see https://bugs.openjdk.org/browse/JDK-8256837)
+        assertEquals("21/Sept/2022:10:30:20 +0000", result);
+        System.out.println(result);
+
+        assertEquals(converter.internalCachingDateFormatter().format(event.getTimeStamp()), result);
+    }
 
     public void testLineLocalPortConverter() {
         LocalPortConverter converter = new LocalPortConverter();

--- a/common/src/main/java/ch/qos/logback/access/common/pattern/DateConverter.java
+++ b/common/src/main/java/ch/qos/logback/access/common/pattern/DateConverter.java
@@ -15,6 +15,7 @@ package ch.qos.logback.access.common.pattern;
 
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Locale;
 
 import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.CoreConstants;
@@ -29,31 +30,37 @@ public class DateConverter extends AccessConverter {
     public void start() {
 
         String datePattern = getFirstOption();
+
         if (datePattern == null) {
             datePattern = CoreConstants.CLF_DATE_PATTERN;
-        }
-
-        if (datePattern.equals(CoreConstants.ISO8601_STR)) {
+        } else if (datePattern.equals(CoreConstants.ISO8601_STR)) {
             datePattern = CoreConstants.ISO8601_PATTERN;
+        } else if (datePattern.equals(CoreConstants.STRICT_STR)) {
+            datePattern = CoreConstants.STRICT_ISO8601_PATTERN;
         }
-        ZoneId zoneId = null;
-        List<String> optionList = getOptionList();
 
+        List<String> optionList = getOptionList();
+        ZoneId zoneId = null;
         // if the option list contains a TZ option, then set it.
         if (optionList != null && optionList.size() > 1) {
             String zoneIdString = (String) optionList.get(1);
             zoneId = ZoneId.of(zoneIdString);
         }
+        Locale locale = null;
+        if (optionList != null && optionList.size() > 2) {
+            String localeIdStr = (String) optionList.get(2);
+            locale = Locale.forLanguageTag(localeIdStr);
+            addInfo("Setting locale to \""+locale+"\"");
+        }
 
         try {
-            cachingDateFormatter = new CachingDateFormatter(datePattern, zoneId);
+            cachingDateFormatter = new CachingDateFormatter(datePattern, zoneId, locale);
             // maximumCacheValidity = CachedDateFormat.getMaximumCacheValidity(pattern);
         } catch (IllegalArgumentException e) {
             addWarn("Could not instantiate SimpleDateFormat with pattern " + datePattern, e);
             addWarn("Defaulting to  " + CoreConstants.CLF_DATE_PATTERN);
             cachingDateFormatter = new CachingDateFormatter(CoreConstants.CLF_DATE_PATTERN, zoneId);
         }
-
     }
 
     @Override


### PR DESCRIPTION
Fixes #18 

Brings DateConverter in logback-access in line with DateConverter in logback-classic.