### PR TITLE
Propagate IO exceptions in TeeServletInputStream

### DIFF
--- a/logback-access-common/src/main/java/ch/qos/logback/access/common/servlet/TeeServletInputStream.java
+++ b/logback-access-common/src/main/java/ch/qos/logback/access/common/servlet/TeeServletInputStream.java
@@ -36,9 +36,15 @@ class TeeServletInputStream extends ServletInputStream {
         try {
             originalSIS = request.getInputStream();
             inputBuffer = consumeBufferAndReturnAsByteArray(originalSIS);
-            this.in = new ByteArrayInputStream(inputBuffer);
+            in = new ByteArrayInputStream(inputBuffer);
         } catch (IOException e) {
-            e.printStackTrace();
+            inputBuffer = new byte[0];
+            in = new InputStream() {
+                @Override
+                public int read() throws IOException {
+                    throw e;
+                }
+            };
         } finally {
             closeStream(originalSIS);
         }

--- a/logback-access-common/src/test/java/ch/qos/logback/access/common/servlet/TeeServletInputStreamTest.java
+++ b/logback-access-common/src/test/java/ch/qos/logback/access/common/servlet/TeeServletInputStreamTest.java
@@ -1,0 +1,115 @@
+package ch.qos.logback.access.common.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class TeeServletInputStreamTest {
+
+    @Test
+    public void testReadsInputStreamFullyAndProvidesInputBuffer() throws IOException {
+        // arrange
+        byte[] bytes = "GET / HTTP/1.1".getBytes();
+        HttpServletRequest request = mockServletRequest(bytes);
+
+        // act
+        try (TeeServletInputStream is = new TeeServletInputStream(request)) {
+            // assert
+            assertArrayEquals(bytes, is.getInputBuffer());
+        }
+    }
+
+    @Test
+    public void testProvidesReadableInputStream() throws IOException {
+        // arrange
+        byte[] bytes = "GET / HTTP/1.1".getBytes();
+        HttpServletRequest request = mockServletRequest(bytes);
+
+        // act
+        try (TeeServletInputStream is = new TeeServletInputStream(request)) {
+            // assert
+            for (byte nextByte : bytes) {
+                assertEquals(nextByte, is.read());
+            }
+            assertEquals(-1, is.read());
+            assertEquals(-1, is.read());
+            assertEquals(-1, is.read());
+        }
+    }
+
+    @Test
+    public void testPropagatesIOExceptionOnRead() throws IOException {
+        // arrange
+        byte[] bytes = "GET / ...".getBytes();
+        HttpServletRequest request = mockServletRequest(bytes, "Read timed out");
+
+        // act
+        try (TeeServletInputStream is = new TeeServletInputStream(request)) {
+            // assert
+            IOException e = assertThrows(IOException.class, () -> { while(is.read() != -1); });
+            assertEquals("Read timed out", e.getMessage());
+            assertArrayEquals(new byte[0], is.getInputBuffer());
+        }
+    }
+
+    private static HttpServletRequest mockServletRequest(byte[] bytes) {
+        return mockServletRequest(bytes, null);
+    }
+
+    private static HttpServletRequest mockServletRequest(byte[] bytes, String ioError) {
+        ServletInputStream inputStream = mockServletInputStream(bytes, ioError);
+
+        ClassLoader classLoader = TeeServletInputStreamTest.class.getClassLoader();
+        Class<?>[] interfaces = new Class<?>[] {HttpServletRequest.class};
+
+        Object servletRequest = Proxy.newProxyInstance(classLoader, interfaces, (object, method, arg) -> {
+            switch (method.getName()) {
+                case "getInputStream": return inputStream;
+                default: throw new UnsupportedOperationException();
+            }
+        });
+
+        return (HttpServletRequest) servletRequest;
+    }
+
+    private static ServletInputStream mockServletInputStream(byte[] bytes, String ioError) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+
+        return new ServletInputStream() {
+            @Override
+            public int read() throws IOException {
+                if (buffer.hasRemaining()) {
+                    return buffer.get();
+                } else if (ioError == null) {
+                    return -1;
+                }
+                throw new IOException(ioError);
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public boolean isFinished() {
+                return buffer.hasRemaining();
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
When the `TeeFilter` is configured as described in [Capturing incoming HTTP requests and outgoing responses](https://logback.qos.ch/recipes/captureHttp.html) any IO exceptions which may occur while reading the HTTP request body are not propagated (see `TeeServletInputStream`):

```java
private void duplicateInputStream(HttpServletRequest request) {
    ServletInputStream originalSIS = null;
    try {
        originalSIS = request.getInputStream();
        inputBuffer = consumeBufferAndReturnAsByteArray(originalSIS);
        this.in = new ByteArrayInputStream(inputBuffer);
    } catch (IOException e) {
        e.printStackTrace();
    } finally {
        closeStream(originalSIS);
    }
}
```

All IO exceptions are caught and the exception stack trace gets printed to the console. In this case `this.in` never gets assigned a value / is still set to `null`.

If a servlet later tries to read from the `ServletInputStream` a `NullPointerException` is thrown instead:

```txt
Caused by: java.lang.NullPointerException: Cannot invoke "java.io.InputStream.read()" because "this.in" is null
    at ch.qos.logback.access.common.servlet.TeeServletInputStream.read(TeeServletInputStream.java:49)
    ...
```

My change propagates the IO exception to the caller when a servlet attempts to read from the stream.

Please let me know your thoughts on these changes or if you have any suggestions for improvements.